### PR TITLE
feat: main functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ MANIFEST
 *.manifest
 *.spec
 
+.idea/
+
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt

--- a/django_authorization/__init__.py
+++ b/django_authorization/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2022 The Casbin Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .casbin_backend import CasbinBackend
+from .middleware import AuthorizationMiddleware

--- a/django_authorization/casbin_backend.py
+++ b/django_authorization/casbin_backend.py
@@ -1,0 +1,34 @@
+# Copyright 2022 The Casbin Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import casbin
+from casbin_adapter.enforcer import enforcer as proxy_enforcer
+
+
+class CasbinBackend:
+    def __init__(self, use_django_orm_adapter=True, model=None, adapter=None):
+        """
+        Initialize the enforcer of Casbin backend.
+        :param use_django_orm_adapter: whether to use the Django ORM adapter.
+        :param model: if not using Django ORM adapter, you should pass the model files as param:model here.
+        :param adapter: if not using Django ORM adapter,
+                        you should pass the adapter or policy files as param:adapter here.
+        """
+        self.enforcer = None
+        self.use_django_orm_adapter = use_django_orm_adapter
+        if use_django_orm_adapter:
+            self.enforcer = proxy_enforcer
+        else:
+            self.enforcer = casbin.Enforcer(model, adapter)
+

--- a/django_authorization/middleware.py
+++ b/django_authorization/middleware.py
@@ -1,0 +1,51 @@
+# Copyright 2022 The Casbin Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from django.core.exceptions import PermissionDenied
+
+
+class AuthorizationMiddleware:
+    """
+    Authorization Middleware
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        # proxy enforcer from casbin_orm_adapter, has been initialized in the adapter
+        self.enforcer = None
+
+    def __call__(self, request):
+        # Check the permission for each request.
+        if not self.check_permission(request):
+            # Not authorized, return HTTP 403 error.
+            self.require_permission()
+
+        # Permission passed, go to next module.
+        response = self.get_response(request)
+        return response
+
+    def set_enforcer(self, enforcer):
+        self.enforcer = enforcer
+
+    def check_permission(self, request):
+        # Customize it based on your authentication method.
+        user = request.user.username
+        if request.user.is_anonymous:
+            user = 'anonymous'
+        path = request.path
+        method = request.method
+        return self.enforcer.enforce(user, path, method)
+
+    def require_permission(self, ):
+        raise PermissionDenied

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+casbin==1.16.9
+casbin_django_orm_adapter==1.0.1
+Django==4.0.6

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+mock==4.0.3

--- a/tests/rbac_model.conf
+++ b/tests/rbac_model.conf
@@ -1,0 +1,14 @@
+[request_definition]
+r = sub, obj, act
+
+[policy_definition]
+p = sub, obj, act
+
+[role_definition]
+g = _, _
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act

--- a/tests/rbac_policy.csv
+++ b/tests/rbac_policy.csv
@@ -1,0 +1,5 @@
+p, alice, data1, read
+p, bob, data2, write
+p, data2_admin, data2, read
+p, data2_admin, data2, write
+g, alice, data2_admin

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,0 +1,46 @@
+import os
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+SECRET_KEY = "not-a-production-secret"
+
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "casbin_adapter.apps.CasbinAdapterConfig",
+    "tests",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "django_authorization.middleware.AuthorizationMiddleware",
+]
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ]
+        },
+    }
+]
+
+DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}
+
+CASBIN_MODEL = os.path.join(BASE_DIR, "tests", "rbac_model.conf")

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,0 +1,84 @@
+# Copyright 2022 The Casbin Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import mock
+from django.core.exceptions import PermissionDenied
+from django.test import TestCase
+
+from django_authorization import AuthorizationMiddleware, CasbinBackend
+
+
+def get_example(path):
+    dir_path = os.path.split(os.path.realpath(__file__))[0] + "/"
+    return os.path.abspath(dir_path + path)
+
+
+class TestConfig(TestCase):
+    def test_backend_with_proxy_enforcer(self):
+        backend = CasbinBackend(use_django_orm_adapter=True)
+        self.assertFalse(backend.enforcer.enforce("alice0", "data1", "read"))
+        backend.enforcer.add_policy("alice0", "data1", "read")
+        backend.enforcer.save_policy()
+        backend.enforcer.load_policy()
+        self.assertTrue(backend.enforcer.enforce("alice0", "data1", "read"))
+        backend.enforcer.remove_policy("alice0", "data1", "read")
+        backend.enforcer.save_policy()
+
+    def test_backend_with_other_enforcer(self):
+        backend = CasbinBackend(use_django_orm_adapter=False, model=get_example('rbac_model.conf'),
+                                adapter=get_example("rbac_policy.csv"))
+        self.assertFalse(backend.enforcer.enforce("alice0", "data1", "read"))
+        backend.enforcer.add_policy("alice0", "data1", "read")
+        backend.enforcer.save_policy()
+        self.assertTrue(backend.enforcer.enforce("alice0", "data1", "read"))
+        backend.enforcer.remove_policy("alice0", "data1", "read")
+        backend.enforcer.save_policy()
+
+    def test_middleware(self):
+
+        get_response = mock.MagicMock()
+
+        request = mock.Mock()
+        request.user = mock.Mock()
+        request.user.is_anonymous = False
+        request.user.username = "alice0"
+        request.path = "/"
+        request.method = "GET"
+
+        backend = CasbinBackend(use_django_orm_adapter=True)
+        middleware = AuthorizationMiddleware(get_response)
+        middleware.set_enforcer(backend.enforcer)
+
+        response = None
+
+        try:
+            response = middleware(request)
+        except PermissionDenied:
+            print(response)
+            pass
+        else:
+            self.fail("PermissionDenied not raised")
+
+        middleware.enforcer.add_policy("alice0", "/", "GET")
+
+        try:
+            response = middleware(request)
+        except PermissionDenied:
+            print(response)
+            self.fail("PermissionDenied shouldn't be raised")
+        else:
+            pass
+


### PR DESCRIPTION
django_orm_adapter contains proxy_enforcer which is made for django(The reason for this is django's special database mechanism：https://github.com/pycasbin/django-orm-adapter/pull/6), So a distinction is made between using django_orm_adapter or not.

**Follow-up: Connect to django's logging system by continuing to modify the logging mechanism in django_orm_adapter**

@leeqvip plz review